### PR TITLE
read_timeout to 240sec

### DIFF
--- a/lib/rubber/cloud/datto.rb
+++ b/lib/rubber/cloud/datto.rb
@@ -87,6 +87,7 @@ module Rubber
       class HttpAdapter
         include ::HTTParty
         format(:json)
+        read_timeout(240)
       end
     end
   end


### PR DESCRIPTION
read_timeout default is 60sec.  That's not long enough for the Datto provisioning API.  
