### PR TITLE
Fixed initial_ssh_user fetch issue

### DIFF
--- a/lib/rubber/recipes/rubber/instances.rb
+++ b/lib/rubber/recipes/rubber/instances.rb
@@ -395,7 +395,7 @@ namespace :rubber do
 
       # Enable root ssh access via key
       # However, current Backupify vagrant setup already does this so we skip it in that case
-      if instance_item.linux? && (instance_item.provider != 'vagrant' && !fetch(:initial_ssh_user))
+      if instance_item.linux? && (instance_item.provider != 'vagrant' && !fetch(:initial_ssh_user, false))
         # weird cap/netssh bug, sometimes just hangs forever on initial connect, so force a timeout
         begin
           Timeout::timeout(30) do


### PR DESCRIPTION
fix for instance create exception:

 *\* Instance running, fetching hostname/ip data
/Users/egorelik/.rbenv/versions/2.1.3/gemsets/backupify/gems/capistrano-2.15.5/lib/capistrano/configuration/variables.rb:82:in `block in fetch':`initial_ssh_user' not found (IndexError)
    from /Users/egorelik/.rbenv/versions/2.1.3/gemsets/backupify/gems/capistrano-2.15.5/lib/capistrano/configuration/variables.rb:110:in `block in protect'
    from /Users/egorelik/.rbenv/versions/2.1.3/gemsets/backupify/gems/capistrano-2.15.5/lib/capistrano/configuration/variables.rb:110:in`synchronize'
