### PR TITLE
yaml based provisioning (wip)

### DIFF
--- a/lib/rubber/cloud/aws.rb
+++ b/lib/rubber/cloud/aws.rb
@@ -452,7 +452,9 @@ module Rubber
 
             # convert the special case default rule into what it actually looks like when
             # we query ec2 so that we can match things up when syncing
-            rules = group['rules'].clone
+            rules = group['rules'].clone\
+            # Make sure rule source ips are in sorted order so we can delete them properly from the rules.
+            rules.each{ |r| r["source_ips"].kind_of?(Array) && r["source_ips"].sort! }
             group['rules'].each do |rule|
               if [2, 3].include?(rule.size) && rule['source_group_name'] && rule['source_group_account']
                 rules << rule.merge({'protocol' => 'tcp', 'from_port' => '1', 'to_port' => '65535' })
@@ -467,6 +469,8 @@ module Rubber
             # first collect the rule maps from the request (group/user pairs are duplicated for tcp/udp/icmp,
             # so we need to do this up frnot and remove duplicates before checking against the local rubber rules)
             cloud_group[:permissions].each do |rule|
+              # Make sure rule source ips are in sorted order so we can delete them properly from the rules.
+              rule[:source_ips].kind_of?(Array) && rule[:source_ips].sort!
               source_groups = rule.delete(:source_groups)
               if source_groups
                 source_groups.each do |source_group|

--- a/lib/rubber/cloud/yaml.rb
+++ b/lib/rubber/cloud/yaml.rb
@@ -78,8 +78,6 @@ module Rubber
         end
       end
 
-      #private
-
       def self.persist_database(database, database_file)
         File.open(database_file + ".tmp", "w") do |f|
           f.write(::YAML.dump(database))

--- a/lib/rubber/cloud/yaml.rb
+++ b/lib/rubber/cloud/yaml.rb
@@ -73,7 +73,7 @@ module Rubber
       end
 
       class Instance < Struct.new(:id, :state, :datacenter, :external_ip, :internal_ip, :platform, :provider)
-        def initialize(id, state, datacenter, external_ip, internal_ip, platform, prodiver)
+        def initialize(id, state, datacenter, external_ip, internal_ip, platform, provider)
           super(id, state || AVAILABLE, datacenter, external_ip, internal_ip, platform, provider)
         end
       end

--- a/lib/rubber/cloud/yaml.rb
+++ b/lib/rubber/cloud/yaml.rb
@@ -1,0 +1,92 @@
+require 'rubber/cloud/generic'
+require 'yaml/store'
+
+module Rubber
+  module Cloud
+    # YAML file containing a set of servers available for use.
+    class YAML < Base
+      PROVIDER = 'YAML'.freeze
+      AVAILABLE = 'available'.freeze
+      ACTIVE = 'running'.freeze
+      STOPPED = 'stopped'.freeze
+
+      def database_file
+        ENV["YAML_DATABASE"]
+      end
+
+      def active_state
+        ACTIVE
+      end
+
+      def stopped_state
+        STOPPED
+      end
+
+      def create_instance(instance_alias, image_name, image_type, security_groups, availability_zone, datacenter)
+        instance = database.select(&find_by_datacenter).find(&find_by_state(AVAILABLE))
+        return nil if instance.nil?
+
+        instance.state = ACTIVE
+
+        dump_database
+
+        instance.id
+      end
+
+      def describe_instances(instance_id=nil)
+        # sanity guard in case someone defined a server without an id.
+        return nil if instance_id.nil?
+
+        instance = database.find(&find_by_uuid(instance_id)).dup
+
+        instance.provider = PROVIDER
+        instance.platform = Rubber::Platforms::LINUX
+
+        instance.to_h
+      end
+
+      def destroy_instance(instance_id)
+        instance = database.find(&find_by_uuid(instance_id))
+        return if instance.nil?
+
+        # Mark the instance as available again.
+        instance.state = AVAILABLE
+
+        dump_database
+      end
+
+      private
+
+      def dump_database
+        File.open(database_file + ".tmp") do |f|
+          f.write(YAML.dump(database))
+        end
+
+        FileUtils.mv(database_file, database_file + ".bak")
+        FileUtils.mv(database_file + ".tmp", database_file)
+      end
+
+      def database
+        @database ||= (YAML.load(File.open(database_file)) || [])
+      # create an empty db if the file doesn't exist.
+      rescue Errno::ENOENT => e
+        @database = []
+      end
+
+      def find_by_state(state)
+        lambda { |i| i.state == state }
+      end
+
+      def find_by_datacenter(datacenter)
+        lambda { |i| i.datacenter == datacenter }
+      end
+
+      # @param [String] id
+      def find_by_uuid(id)
+        lambda { |i| i.id == id }
+      end
+
+      class Instance < Struct.new(:id, :state, :datacenter, :external_ip, :internal_ip, :platform, :provider); end
+    end
+  end
+end

--- a/lib/rubber/cloud/yaml.rb
+++ b/lib/rubber/cloud/yaml.rb
@@ -34,7 +34,7 @@ module Rubber
 
         instance.state = ACTIVE
 
-        self.class.dump_database(db, database_file)
+        self.class.persist_database(db, database_file)
 
         instance.id
       end
@@ -69,7 +69,7 @@ module Rubber
         # Mark the instance as available again.
         instance.state = AVAILABLE
 
-        self.class.dump_database(db, database_file)
+        self.class.persist_database(db, database_file)
       end
 
       class Instance < Struct.new(:id, :state, :datacenter, :external_ip, :internal_ip, :platform, :provider)
@@ -80,7 +80,7 @@ module Rubber
 
       #private
 
-      def self.dump_database(database, database_file)
+      def self.persist_database(database, database_file)
         File.open(database_file + ".tmp", "w") do |f|
           f.write(::YAML.dump(database))
         end

--- a/lib/rubber/cloud/yaml.rb
+++ b/lib/rubber/cloud/yaml.rb
@@ -79,8 +79,8 @@ module Rubber
       # just return.
       def destroy_instance(instance_id)
         db = self.class.load_database(database_file)
-        instance = db.find(&find_by_uuid(instance_id))
-        return if instance.nil?
+        instance = db.select(&find_by_states(ACTIVE, STOPPED)).find(&find_by_uuid(instance_id))
+        raise StandardError.new("No Server Matches ID") if instance.nil?
 
         # Mark the instance as available again.
         instance.state = AVAILABLE

--- a/lib/rubber/cloud/yaml.rb
+++ b/lib/rubber/cloud/yaml.rb
@@ -6,7 +6,7 @@ module Rubber
     # YAML file containing a set of servers available for use.
     # Implements the rubber's provisioner interface
     # create_instance, describe_instances, destroy_instance
-    class YAML < Base
+    class Yaml < Base
       AVAILABLE = 'available'.freeze
       ACTIVE = 'running'.freeze
       STOPPED = 'stopped'.freeze # not actually used just defined to implement the cloud interface

--- a/lib/rubber/cloud/yaml.rb
+++ b/lib/rubber/cloud/yaml.rb
@@ -35,7 +35,7 @@ module Rubber
       def create_instance(_instance_alias, _image_name, _image_type, _security_groups, _availability_zone, datacenter)
         instances = db = self.class.load_database(database_file)
 
-        if datacenter.length > 0
+        if datacenter && datacenter.length > 0
           instances = db.select(&find_by_datacenter(datacenter))
         end
 

--- a/test/cloud/yaml_test.rb
+++ b/test/cloud/yaml_test.rb
@@ -37,6 +37,7 @@ class YAMLTest < Test::Unit::TestCase
 
         instances = @cloud.describe_instances
         assert_equal 2, instances.count
+        refute instances.collect{|hash| hash[:id]}.include?(db.last.id)
       end
 
       should 'return empty array if no instances' do
@@ -59,12 +60,17 @@ class YAMLTest < Test::Unit::TestCase
 
         Rubber::Cloud::YAML.dump_database(db, ENV["YAML_DATABASE"])
 
+        assert_equal 0, @cloud.describe_instances.count
+
         # create an instance
         instance_id = @cloud.create_instance('', '', '', '', '', '')
 
         instances = @cloud.describe_instances(instance_id)
 
-        assert_equal 1, instances.length
+        assert_equal 1, instances.count
+        [:id, :datacenter, :external_ip, :internal_ip].each do |attr|
+          assert_equal db.first.send(attr), instances.first[attr]
+        end
       end
     end
   end

--- a/test/cloud/yaml_test.rb
+++ b/test/cloud/yaml_test.rb
@@ -22,6 +22,11 @@ class YAMLTest < Test::Unit::TestCase
       Rubber::Cloud::YAML.persist_database(db, ENV["YAML_DATABASE"])
 
       assert_equal db.first.id, @cloud.create_instance('', '', '', '', '', '')
+      instance = @cloud.describe_instances(db.first.id).first
+
+      # ensure creating the instance populated the two missing fields.
+      assert_equal instance[:provider], 'YAML'
+      assert_equal instance[:platform], Rubber::Platforms::LINUX
     end
 
     context 'describe_instances' do

--- a/test/cloud/yaml_test.rb
+++ b/test/cloud/yaml_test.rb
@@ -19,7 +19,7 @@ class YAMLTest < Test::Unit::TestCase
         Rubber::Cloud::YAML::Instance.new(SecureRandom.uuid, Rubber::Cloud::YAML::AVAILABLE, 'dc0', '127.0.0.1', '10.0.0.1', nil, nil),
       ]
 
-      Rubber::Cloud::YAML.dump_database(db, ENV["YAML_DATABASE"])
+      Rubber::Cloud::YAML.persist_database(db, ENV["YAML_DATABASE"])
 
       assert_equal db.first.id, @cloud.create_instance('', '', '', '', '', '')
     end
@@ -33,7 +33,7 @@ class YAMLTest < Test::Unit::TestCase
         ]
 
         # Load DB.
-        Rubber::Cloud::YAML.dump_database(db, ENV["YAML_DATABASE"])
+        Rubber::Cloud::YAML.persist_database(db, ENV["YAML_DATABASE"])
 
         instances = @cloud.describe_instances
         assert_equal 2, instances.count
@@ -58,7 +58,7 @@ class YAMLTest < Test::Unit::TestCase
           Rubber::Cloud::YAML::Instance.new(SecureRandom.uuid, Rubber::Cloud::YAML::AVAILABLE, 'dc0', '127.0.0.1', '10.0.0.1', nil, nil),
         ]
 
-        Rubber::Cloud::YAML.dump_database(db, ENV["YAML_DATABASE"])
+        Rubber::Cloud::YAML.persist_database(db, ENV["YAML_DATABASE"])
 
         assert_equal 0, @cloud.describe_instances.count
 

--- a/test/cloud/yaml_test.rb
+++ b/test/cloud/yaml_test.rb
@@ -78,5 +78,41 @@ class YAMLTest < Test::Unit::TestCase
         end
       end
     end
+
+    context 'destroy instance' do
+      should 'update the database for a running server from running to available' do
+        active = Rubber::Cloud::YAML::Instance.new(SecureRandom.uuid, Rubber::Cloud::YAML::ACTIVE, 'dc0', '127.0.0.1', '10.0.0.1', nil, nil)
+        stopped = Rubber::Cloud::YAML::Instance.new(SecureRandom.uuid, Rubber::Cloud::YAML::STOPPED, 'dc1', '127.0.0.2', '10.0.0.2', nil, nil)
+        available = Rubber::Cloud::YAML::Instance.new(SecureRandom.uuid, Rubber::Cloud::YAML::AVAILABLE, 'dc1', '127.0.0.3', '10.0.0.3', nil, nil)
+
+        db = [active, stopped, available]
+
+        # Load DB.
+        Rubber::Cloud::YAML.persist_database(db, ENV["YAML_DATABASE"])
+
+        assert_equal 2, @cloud.describe_instances.count
+
+        @cloud.destroy_instance(active.id)
+
+        assert_equal 1, @cloud.describe_instances.count
+      end
+
+      should 'update the database for a running server from stopped to available' do
+        active = Rubber::Cloud::YAML::Instance.new(SecureRandom.uuid, Rubber::Cloud::YAML::ACTIVE, 'dc0', '127.0.0.1', '10.0.0.1', nil, nil)
+        stopped = Rubber::Cloud::YAML::Instance.new(SecureRandom.uuid, Rubber::Cloud::YAML::STOPPED, 'dc1', '127.0.0.2', '10.0.0.2', nil, nil)
+        available = Rubber::Cloud::YAML::Instance.new(SecureRandom.uuid, Rubber::Cloud::YAML::AVAILABLE, 'dc1', '127.0.0.3', '10.0.0.3', nil, nil)
+
+        db = [active, stopped, available]
+
+        # Load DB.
+        Rubber::Cloud::YAML.persist_database(db, ENV["YAML_DATABASE"])
+
+        assert_equal 2, @cloud.describe_instances.count
+
+        @cloud.destroy_instance(stopped.id)
+
+        assert_equal 1, @cloud.describe_instances.count
+      end
+    end
   end
 end

--- a/test/cloud/yaml_test.rb
+++ b/test/cloud/yaml_test.rb
@@ -14,19 +14,36 @@ class YAMLTest < Test::Unit::TestCase
       FileUtils.rm_f(ENV.delete("YAML_DATABASE"))
     end
 
-    should 'create instance' do
-      db = [
-        Rubber::Cloud::Yaml::Instance.new(SecureRandom.uuid, Rubber::Cloud::Yaml::AVAILABLE, 'dc0', '127.0.0.1', '10.0.0.1', nil, nil),
-      ]
+    context 'create_instance' do
+      should 'create instance' do
+        db = [
+          Rubber::Cloud::Yaml::Instance.new(SecureRandom.uuid, Rubber::Cloud::Yaml::AVAILABLE, 'dc0', '127.0.0.1', '10.0.0.1', nil, nil),
+        ]
 
-      Rubber::Cloud::Yaml.persist_database(db, ENV["YAML_DATABASE"])
+        Rubber::Cloud::Yaml.persist_database(db, ENV["YAML_DATABASE"])
 
-      assert_equal db.first.id, @cloud.create_instance('', '', '', '', '', '')
-      instance = @cloud.describe_instances(db.first.id).first
+        assert_equal db.first.id, @cloud.create_instance('', '', '', '', '', '')
+        instance = @cloud.describe_instances(db.first.id).first
 
-      # ensure creating the instance populated the two missing fields.
-      assert_equal instance[:provider], 'Yaml'
-      assert_equal instance[:platform], Rubber::Platforms::LINUX
+        # ensure creating the instance populated the two missing fields.
+        assert_equal instance[:provider], 'Yaml'
+        assert_equal instance[:platform], Rubber::Platforms::LINUX
+      end
+
+      should 'handle nil datacenter' do
+        db = [
+          Rubber::Cloud::Yaml::Instance.new(SecureRandom.uuid, Rubber::Cloud::Yaml::AVAILABLE, nil, '127.0.0.1', '10.0.0.1', nil, nil),
+        ]
+
+        Rubber::Cloud::Yaml.persist_database(db, ENV["YAML_DATABASE"])
+
+        assert_equal db.first.id, @cloud.create_instance('', '', '', '', '', nil)
+        instance = @cloud.describe_instances(db.first.id).first
+
+        # ensure creating the instance populated the two missing fields.
+        assert_equal instance[:provider], 'Yaml'
+        assert_equal instance[:platform], Rubber::Platforms::LINUX
+      end
     end
 
     context 'describe_instances' do

--- a/test/cloud/yaml_test.rb
+++ b/test/cloud/yaml_test.rb
@@ -1,0 +1,58 @@
+require File.expand_path(File.join(__FILE__, '../..', 'test_helper'))
+require 'rubber/cloud/yaml'
+
+# NOTE: Must re-record one at a time for any test that invokes create_instance.
+# This is true until we allow povisioning arbitrarily, or if you expect the instances list to
+# be empty.
+class YAMLTest < Test::Unit::TestCase
+  context 'yaml' do
+    setup do
+      @dbfile = "/tmp/#{SecureRandom.uuid}"
+      # env = {
+      #   'database' => @dbfile,
+      # }
+
+      env = Rubber::Configuration::Environment::BoundEnv.new(env, nil, nil, nil)
+      @cloud = Rubber::Cloud::YAML.new(env, nil)
+    end
+
+    teardown do
+      FileUtils.rm(@dbfile)
+    end
+
+    should 'create instance' do
+      assert @cloud.create_instance('', '', '', '', '', '')
+    end
+
+    context 'describe_instances' do
+      should 'be able to describe all instances if no instance id is provided' do
+        # create an instance
+        assert @cloud.create_instance('', '', '', '', '', '')
+
+        instances = @cloud.describe_instances
+        assert_equal 1, instances.count
+      end
+
+      should 'return empty array if no instances' do
+        assert @cloud.describe_instances.empty?
+      end
+
+      # Current behaviour not sure if this is what we want long term.
+      should 'error if the provided instance id does not exist' do
+        exception = assert_raises(StandardError)do
+          assert @cloud.describe_instances("0000")
+        end
+        assert "Worker 0000 doesn't exist", exception.message
+      end
+
+      should 'return just information about the requested instance' do
+        # create an instance
+        instance_id = @cloud.create_instance('', '', '', '', '', '')
+
+        instances = @cloud.describe_instances
+
+        assert_equal Integer(instance_id, 10), instances.first[:id]
+      end
+    end
+  end
+end

--- a/test/cloud/yaml_test.rb
+++ b/test/cloud/yaml_test.rb
@@ -7,7 +7,7 @@ class YAMLTest < Test::Unit::TestCase
       ENV["YAML_DATABASE"] = "/tmp/#{SecureRandom.uuid}"
 
       env = Rubber::Configuration::Environment::BoundEnv.new({}, nil, nil, nil)
-      @cloud = Rubber::Cloud::YAML.new(env, nil)
+      @cloud = Rubber::Cloud::Yaml.new(env, nil)
     end
 
     teardown do
@@ -16,29 +16,29 @@ class YAMLTest < Test::Unit::TestCase
 
     should 'create instance' do
       db = [
-        Rubber::Cloud::YAML::Instance.new(SecureRandom.uuid, Rubber::Cloud::YAML::AVAILABLE, 'dc0', '127.0.0.1', '10.0.0.1', nil, nil),
+        Rubber::Cloud::Yaml::Instance.new(SecureRandom.uuid, Rubber::Cloud::Yaml::AVAILABLE, 'dc0', '127.0.0.1', '10.0.0.1', nil, nil),
       ]
 
-      Rubber::Cloud::YAML.persist_database(db, ENV["YAML_DATABASE"])
+      Rubber::Cloud::Yaml.persist_database(db, ENV["YAML_DATABASE"])
 
       assert_equal db.first.id, @cloud.create_instance('', '', '', '', '', '')
       instance = @cloud.describe_instances(db.first.id).first
 
       # ensure creating the instance populated the two missing fields.
-      assert_equal instance[:provider], 'YAML'
+      assert_equal instance[:provider], 'Yaml'
       assert_equal instance[:platform], Rubber::Platforms::LINUX
     end
 
     context 'describe_instances' do
       should 'be able to describe all instances if no instance id is provided' do
         db = [
-          Rubber::Cloud::YAML::Instance.new(SecureRandom.uuid, Rubber::Cloud::YAML::ACTIVE, 'dc0', '127.0.0.1', '10.0.0.1', nil, nil),
-          Rubber::Cloud::YAML::Instance.new(SecureRandom.uuid, Rubber::Cloud::YAML::STOPPED, 'dc1', '127.0.0.2', '10.0.0.2', nil, nil),
-          Rubber::Cloud::YAML::Instance.new(SecureRandom.uuid, Rubber::Cloud::YAML::AVAILABLE, 'dc1', '127.0.0.3', '10.0.0.3', nil, nil),
+          Rubber::Cloud::Yaml::Instance.new(SecureRandom.uuid, Rubber::Cloud::Yaml::ACTIVE, 'dc0', '127.0.0.1', '10.0.0.1', nil, nil),
+          Rubber::Cloud::Yaml::Instance.new(SecureRandom.uuid, Rubber::Cloud::Yaml::STOPPED, 'dc1', '127.0.0.2', '10.0.0.2', nil, nil),
+          Rubber::Cloud::Yaml::Instance.new(SecureRandom.uuid, Rubber::Cloud::Yaml::AVAILABLE, 'dc1', '127.0.0.3', '10.0.0.3', nil, nil),
         ]
 
         # Load DB.
-        Rubber::Cloud::YAML.persist_database(db, ENV["YAML_DATABASE"])
+        Rubber::Cloud::Yaml.persist_database(db, ENV["YAML_DATABASE"])
 
         instances = @cloud.describe_instances
         assert_equal 2, instances.count
@@ -60,10 +60,10 @@ class YAMLTest < Test::Unit::TestCase
 
       should 'return just information about the requested instance' do
         db = [
-          Rubber::Cloud::YAML::Instance.new(SecureRandom.uuid, Rubber::Cloud::YAML::AVAILABLE, 'dc0', '127.0.0.1', '10.0.0.1', nil, nil),
+          Rubber::Cloud::Yaml::Instance.new(SecureRandom.uuid, Rubber::Cloud::Yaml::AVAILABLE, 'dc0', '127.0.0.1', '10.0.0.1', nil, nil),
         ]
 
-        Rubber::Cloud::YAML.persist_database(db, ENV["YAML_DATABASE"])
+        Rubber::Cloud::Yaml.persist_database(db, ENV["YAML_DATABASE"])
 
         assert_equal 0, @cloud.describe_instances.count
 
@@ -81,14 +81,14 @@ class YAMLTest < Test::Unit::TestCase
 
     context 'destroy instance' do
       should 'update the database for a running server from running to available' do
-        active = Rubber::Cloud::YAML::Instance.new(SecureRandom.uuid, Rubber::Cloud::YAML::ACTIVE, 'dc0', '127.0.0.1', '10.0.0.1', nil, nil)
-        stopped = Rubber::Cloud::YAML::Instance.new(SecureRandom.uuid, Rubber::Cloud::YAML::STOPPED, 'dc1', '127.0.0.2', '10.0.0.2', nil, nil)
-        available = Rubber::Cloud::YAML::Instance.new(SecureRandom.uuid, Rubber::Cloud::YAML::AVAILABLE, 'dc1', '127.0.0.3', '10.0.0.3', nil, nil)
+        active = Rubber::Cloud::Yaml::Instance.new(SecureRandom.uuid, Rubber::Cloud::Yaml::ACTIVE, 'dc0', '127.0.0.1', '10.0.0.1', nil, nil)
+        stopped = Rubber::Cloud::Yaml::Instance.new(SecureRandom.uuid, Rubber::Cloud::Yaml::STOPPED, 'dc1', '127.0.0.2', '10.0.0.2', nil, nil)
+        available = Rubber::Cloud::Yaml::Instance.new(SecureRandom.uuid, Rubber::Cloud::Yaml::AVAILABLE, 'dc1', '127.0.0.3', '10.0.0.3', nil, nil)
 
         db = [active, stopped, available]
 
         # Load DB.
-        Rubber::Cloud::YAML.persist_database(db, ENV["YAML_DATABASE"])
+        Rubber::Cloud::Yaml.persist_database(db, ENV["YAML_DATABASE"])
 
         assert_equal 2, @cloud.describe_instances.count
 
@@ -98,14 +98,14 @@ class YAMLTest < Test::Unit::TestCase
       end
 
       should 'update the database for a running server from stopped to available' do
-        active = Rubber::Cloud::YAML::Instance.new(SecureRandom.uuid, Rubber::Cloud::YAML::ACTIVE, 'dc0', '127.0.0.1', '10.0.0.1', nil, nil)
-        stopped = Rubber::Cloud::YAML::Instance.new(SecureRandom.uuid, Rubber::Cloud::YAML::STOPPED, 'dc1', '127.0.0.2', '10.0.0.2', nil, nil)
-        available = Rubber::Cloud::YAML::Instance.new(SecureRandom.uuid, Rubber::Cloud::YAML::AVAILABLE, 'dc1', '127.0.0.3', '10.0.0.3', nil, nil)
+        active = Rubber::Cloud::Yaml::Instance.new(SecureRandom.uuid, Rubber::Cloud::Yaml::ACTIVE, 'dc0', '127.0.0.1', '10.0.0.1', nil, nil)
+        stopped = Rubber::Cloud::Yaml::Instance.new(SecureRandom.uuid, Rubber::Cloud::Yaml::STOPPED, 'dc1', '127.0.0.2', '10.0.0.2', nil, nil)
+        available = Rubber::Cloud::Yaml::Instance.new(SecureRandom.uuid, Rubber::Cloud::Yaml::AVAILABLE, 'dc1', '127.0.0.3', '10.0.0.3', nil, nil)
 
         db = [active, stopped, available]
 
         # Load DB.
-        Rubber::Cloud::YAML.persist_database(db, ENV["YAML_DATABASE"])
+        Rubber::Cloud::Yaml.persist_database(db, ENV["YAML_DATABASE"])
 
         assert_equal 2, @cloud.describe_instances.count
 
@@ -115,14 +115,14 @@ class YAMLTest < Test::Unit::TestCase
       end
 
       should 'error if destroy is called on an available server' do
-        active = Rubber::Cloud::YAML::Instance.new(SecureRandom.uuid, Rubber::Cloud::YAML::ACTIVE, 'dc0', '127.0.0.1', '10.0.0.1', nil, nil)
-        stopped = Rubber::Cloud::YAML::Instance.new(SecureRandom.uuid, Rubber::Cloud::YAML::STOPPED, 'dc1', '127.0.0.2', '10.0.0.2', nil, nil)
-        available = Rubber::Cloud::YAML::Instance.new(SecureRandom.uuid, Rubber::Cloud::YAML::AVAILABLE, 'dc1', '127.0.0.3', '10.0.0.3', nil, nil)
+        active = Rubber::Cloud::Yaml::Instance.new(SecureRandom.uuid, Rubber::Cloud::Yaml::ACTIVE, 'dc0', '127.0.0.1', '10.0.0.1', nil, nil)
+        stopped = Rubber::Cloud::Yaml::Instance.new(SecureRandom.uuid, Rubber::Cloud::Yaml::STOPPED, 'dc1', '127.0.0.2', '10.0.0.2', nil, nil)
+        available = Rubber::Cloud::Yaml::Instance.new(SecureRandom.uuid, Rubber::Cloud::Yaml::AVAILABLE, 'dc1', '127.0.0.3', '10.0.0.3', nil, nil)
 
         db = [active, stopped, available]
 
         # Load DB.
-        Rubber::Cloud::YAML.persist_database(db, ENV["YAML_DATABASE"])
+        Rubber::Cloud::Yaml.persist_database(db, ENV["YAML_DATABASE"])
 
         assert_equal 2, @cloud.describe_instances.count
 

--- a/test/fixtures/instance_expansion/rubber.yml
+++ b/test/fixtures/instance_expansion/rubber.yml
@@ -1,1 +1,4 @@
 var1: "#{rubber_instances.for_role('role1').first.external_ip}"
+hosts:
+  host1:
+    test_var: "foo!"

--- a/test/instance_test.rb
+++ b/test/instance_test.rb
@@ -2,7 +2,7 @@ require File.expand_path(File.join(__FILE__, '..', 'test_helper'))
 
 class InstanceTest < Test::Unit::TestCase
   include Rubber::Configuration
-  
+
   def instance_setup
     @instance = Instance.new("file:#{Tempfile.new('testforrole').path}")
     @instance.add(@i1 = InstanceItem.new('host1', 'domain.com', [RoleItem.new('role1')], '', 'm1.small', 'ami-7000f019'))
@@ -12,13 +12,13 @@ class InstanceTest < Test::Unit::TestCase
   end
 
   context "instance" do
-  
+
     setup do
       instance_setup
     end
-    
+
     context "for_role" do
-    
+
       should "give the right instances for selected role" do
         assert_equal 2, @instance.for_role('role1').size, 'not finding correct instances for role'
         assert_equal 2, @instance.for_role('role2').size, 'not finding correct instances for role'
@@ -27,128 +27,128 @@ class InstanceTest < Test::Unit::TestCase
         assert_equal 1, @instance.for_role('role2', 'primary' => true).size, 'not finding correct instances for role'
         assert_equal @i4, @instance.for_role('role2', 'primary' => true).first, 'not finding correct instances for role'
       end
-      
+
     end
-      
+
     context "filtering" do
-      
+
       should "not filter for empty FILTER(_ROLES)" do
         ENV['FILTER'] = nil
         ENV['FILTER_ROLES'] = nil
         instance_setup
-        assert_equal 4, @instance.filtered().size 
+        assert_equal 4, @instance.filtered().size
       end
-    
-    
+
+
       should "filter hosts" do
         ENV['FILTER_ROLES'] = nil
         ENV['FILTER'] = 'host1'
         instance_setup
         assert_equal [@i1].sort, @instance.filtered().sort, 'should have only filtered host'
-        
+
         ENV['FILTER'] = 'host2 , host4'
         instance_setup
         assert_equal [@i2, @i4].sort, @instance.filtered().sort, 'should have only filtered hosts'
-    
+
         ENV['FILTER'] = '-host2'
         instance_setup
         assert_equal [@i1, @i3, @i4].sort, @instance.filtered().sort, 'should not have negated hosts'
-    
+
         ENV['FILTER'] = 'host1,host2,-host2'
         instance_setup
         assert_equal [@i1].sort, @instance.filtered().sort, 'should not have negated hosts'
-    
+
         ENV['FILTER'] = 'host1~host3'
         instance_setup
         assert_equal [@i1, @i2, @i3].sort, @instance.filtered().sort, 'should allow range in filter'
-    
+
         ENV['FILTER'] = '-host1~-host3'
         instance_setup
         assert_equal [@i4].sort, @instance.filtered().sort, 'should allow negative range in filter'
-    
+
         ENV['FILTER'] = '-host1'
         ENV['FILTER_ROLES'] = 'role1'
         instance_setup
         assert_equal [@i2].sort, @instance.filtered().sort, 'should not have negated roles'
       end
-    
+
       should "filter roles" do
         ENV['FILTER'] = nil
         ENV['FILTER_ROLES'] = 'role1'
         instance_setup
         assert_equal [@i1, @i2].sort, @instance.filtered().sort, 'should have only filtered roles'
-    
+
         ENV['FILTER_ROLES'] = 'role1 , role2'
         instance_setup
         assert_equal [@i1, @i2, @i3, @i4].sort, @instance.filtered().sort, 'should have only filtered roles'
-    
+
         ENV['FILTER_ROLES'] = '-role1'
         instance_setup
         assert_equal [@i3, @i4].sort, @instance.filtered().sort, 'should not have negated roles'
-    
+
         ENV['FILTER_ROLES'] = 'role1~role2'
         instance_setup
         assert_equal [@i1, @i2, @i3, @i4].sort, @instance.filtered().sort, 'should allow range in filter'
-    
+
         ENV['FILTER_ROLES'] = '-role1~-role2'
         instance_setup
         assert_equal [].sort, @instance.filtered().sort, 'should allow negative range in filter'
       end
-    
+
       should "validate filters" do
         ENV['FILTER'] = "nohost"
         instance_setup
         assert_raises do
           @instance.filtered()
         end
-    
+
         ENV['FILTER'] = "-nohost"
         instance_setup
         assert_raises do
           @instance.filtered()
         end
-    
+
         ENV['FILTER_ROLES'] = "norole"
         instance_setup
         assert_raises do
           @instance.filtered()
         end
-    
+
         ENV['FILTER_ROLES'] = "-norole"
         instance_setup
         assert_raises do
           @instance.filtered()
         end
       end
-      
+
     end
-      
-  
+
+
     should "be equal" do
       assert RoleItem.new('a').eql?(RoleItem.new('a'))
       assert RoleItem.new('a') == RoleItem.new('a')
       assert_equal RoleItem.new('a').hash, RoleItem.new('a').hash
-  
+
       assert ! RoleItem.new('a').eql?(RoleItem.new('b'))
       assert RoleItem.new('a') != RoleItem.new('b')
       assert_not_equal RoleItem.new('a').hash, RoleItem.new('b').hash
-  
+
       assert RoleItem.new('a', {'a' => 'b', 1 => true}).eql?(RoleItem.new('a', {'a' => 'b', 1 => true}))
       assert RoleItem.new('a', {'a' => 'b', 1 => true}) == RoleItem.new('a', {'a' => 'b', 1 => true})
       assert_equal RoleItem.new('a', {'a' => 'b', 1 => true}).hash, RoleItem.new('a', {'a' => 'b', 1 => true}).hash
-  
+
       assert ! RoleItem.new('a', {'a' => 'b', 1 => true}).eql?(RoleItem.new('a', {'a' => 'b', 2 => true}))
       assert RoleItem.new('a', {'a' => 'b', 1 => true}) != RoleItem.new('a', {'a' => 'b', 2 => true})
       assert_equal RoleItem.new('a', {'a' => 'b', 1 => true}).hash, RoleItem.new('a', {'a' => 'b', 2 => true}).hash
     end
-  
+
     should "parse roles" do
       assert_equal RoleItem.new('a'), RoleItem.parse("a")
       assert_equal RoleItem.new('a', {'b' => 'c'}), RoleItem.parse("a:b=c")
       assert_equal RoleItem.new('a', {'b' => 'c', 'd' => 'e'}), RoleItem.parse("a:b=c;d=e")
       assert_equal RoleItem.new('a', {'b' => true, 'c' => false}), RoleItem.parse("a:b=true;c=false")
     end
-  
+
     should "convert to a string" do
       assert_equal "a", RoleItem.new('a').to_s
       assert_equal "a:b=c", RoleItem.new('a', {'b' => 'c'}).to_s
@@ -157,9 +157,9 @@ class InstanceTest < Test::Unit::TestCase
       assert_equal "a:b=true", RoleItem.new('a', {'b' => true}).to_s
       assert_equal "a:b=false", RoleItem.new('a', {'b' => false}).to_s
     end
-  
+
     context "role dependencies" do
-      
+
       should "expand role dependencies" do
         deps = { RoleItem.new('a') => RoleItem.new('b'),
                  RoleItem.new('b') => RoleItem.new('c'),
@@ -167,7 +167,7 @@ class InstanceTest < Test::Unit::TestCase
         roles = [RoleItem.new('a'),RoleItem.new('b'),RoleItem.new('c'),RoleItem.new('d')]
         assert_equal roles, RoleItem.expand_role_dependencies(RoleItem.new('a'), deps).sort
         assert_equal roles, RoleItem.expand_role_dependencies([RoleItem.new('a'), RoleItem.new('d')], deps).sort
-    
+
         deps = { RoleItem.new('mysql_master') => RoleItem.new('db', {'primary' => true}),
                  RoleItem.new('mysql_slave') => RoleItem.new('db'),
                  RoleItem.new('db', {'primary' => true}) => RoleItem.new('mysql_master'),
@@ -181,21 +181,21 @@ class InstanceTest < Test::Unit::TestCase
                      RoleItem.expand_role_dependencies(RoleItem.new('mysql_slave'), deps).sort
         assert_equal [RoleItem.new('db'), RoleItem.new('mysql_slave')],
                      RoleItem.expand_role_dependencies(RoleItem.new('db'), deps).sort
-    
+
       end
-    
+
       should "expand dependencie for common role" do
         deps = { RoleItem.new('a') => RoleItem.new('b'),
                  RoleItem.new('common') => [RoleItem.new('c')]}
         roles = [RoleItem.new('a'), RoleItem.new('b'), RoleItem.new('c')]
         assert_equal roles, RoleItem.expand_role_dependencies(RoleItem.new('a'), deps).sort
       end
-      
+
     end
-    
+
     context "cloud storage" do
       require 'rubber/cloud/aws'
-      
+
       setup do
         env = {'access_key' => "XXX", 'secret_access_key' => "YYY", 'region' => "us-east-1"}
         env = Rubber::Configuration::Environment::BoundEnv.new(env, nil, nil, nil)
@@ -203,19 +203,19 @@ class InstanceTest < Test::Unit::TestCase
         @cloud.storage_provider.put_bucket('bucket')
         Rubber.stubs(:cloud).returns(@cloud)
       end
-      
+
       should "fail for invalid instance_storage protocol" do
         Instance.new('file:baz')
 
         @cloud.storage('bucket').store('key', '')
         Instance.new('storage:bucket/key')
-        
+
         Instance.any_instance.stubs(:load_from_table)
         Instance.new('table:bar')
-        
+
         assert_raises { Instance.new('foo:bar') }
       end
-      
+
       should "load and save from file when file given" do
         location = "file:#{Tempfile.new('instancestorage').path}"
         Instance.any_instance.expects(:load_from_file)
@@ -234,12 +234,12 @@ class InstanceTest < Test::Unit::TestCase
         Instance.any_instance.expects(:save_to_file)
         Instance.new(location).save
       end
-      
+
       should "load and save from storage when storage given" do
         @cloud.storage('bucket').store('key', '')
         Instance.any_instance.expects(:load_from_file)
         Instance.any_instance.expects(:save_to_file)
-        Instance.new('storage:bucket/key').save        
+        Instance.new('storage:bucket/key').save
       end
 
       should "create a new instance in cloud storage when the instance file doesn't exist" do
@@ -251,31 +251,31 @@ class InstanceTest < Test::Unit::TestCase
       should "load and save from table when table given" do
         Instance.any_instance.expects(:load_from_table)
         Instance.any_instance.expects(:save_to_table)
-        Instance.new('table:foobar').save        
+        Instance.new('table:foobar').save
       end
-      
+
       should "backup on save when desired" do
         location_file = Tempfile.new('instancestorage').path
         location = "file:#{location_file}"
         backup_file = Tempfile.new('instancestoragebackup').path
         backup = "file:#{backup_file}"
-        
-        
-        instance = Instance.new(location, :backup => backup) 
+
+
+        instance = Instance.new(location, :backup => backup)
         instance.add(@i1 = InstanceItem.new('host1', 'domain.com', [RoleItem.new('role1')], '', 'm1.small', 'ami-7000f019'))
         instance.save
-        
+
         location_data = File.read(location_file)
         backup_data = File.read(backup_file)
         assert location_data.size > 0
         assert backup_data.size > 0
         assert_equal location_data, backup_data
       end
-      
+
     end
-    
+
     context "instance items" do
-      
+
       setup do
         @hash = {
             'name' => 'host1',
@@ -287,7 +287,7 @@ class InstanceTest < Test::Unit::TestCase
             'security_groups' => ['sg1', 'sg2']
         }
       end
-      
+
       should "create from a hash" do
         item = InstanceItem.from_hash(@hash)
         assert_equal 'host1', item.name
@@ -298,7 +298,7 @@ class InstanceTest < Test::Unit::TestCase
         assert_equal 'ami-7000f019', item.image_id
         assert_equal ['sg1', 'sg2'], item.security_groups
       end
-      
+
       should "output as a hash" do
         item = InstanceItem.new('host1',
                                  'domain.com',
@@ -309,9 +309,33 @@ class InstanceTest < Test::Unit::TestCase
                                  ['sg1', 'sg2'])
         assert_equal @hash, item.to_hash()
       end
-      
+
+      context "rubber_config_env" do
+        should "raise if name is not set" do
+          @hash.delete('name')
+          item = InstanceItem.from_hash(@hash)
+          error = assert_raises { item.rubber_config_env }
+          expected = "This convenience method needs 'name' to be set"
+          assert_equal expected, error.message
+        end
+
+        should "return config environment for the subject instance" do
+          item = InstanceItem.from_hash(@hash)
+          test_config = Rubber::Configuration.get_configuration(item.name, "#{File.dirname(__FILE__)}/fixtures/instance_expansion")
+          Rubber::Configuration.expects(:get_configuration).with(item.name).returns(test_config)
+
+          # The unbound env shouldn't have instance-specific keys
+          refute test_config.environment.bind.has_key?('test_var')
+
+          # The result from the call to rubber_config_env should have instance-specific keys
+          result = item.rubber_config_env
+          assert result.has_key?('test_var')
+          assert_equal "foo!", result.test_var
+        end
+      end
+
     end
-    
+
   end
-  
+
 end


### PR DESCRIPTION
allow us to define servers inside a yaml file.

Usage:

```
RUBBER_ENV=production YAML_DATABASE=baremetal/servers.yml CLOUD_PROVIDER=YAML cap rubber:create ALIAS='abc123'
```

use environment variable to allow separate dbs for different types of servers. YAML_DATABASE path in example is just that an example and not some magic location.

YAML Structure:

```

---
  - !ruby/struct:Rubber::Cloud::YAML::Instance
     id: acc79acd-972e-480e-bd46-92a91fa86e83
     state: running
     datacenter: dc0
     external_ip: 127.0.0.1
     internal_ip: 10.0.0.1
     platform: Linux
     provider: YAML
  - !ruby/struct:Rubber::Cloud::YAML::Instance
     id: 82ccfa93-59cf-437e-9026-109a2f4f1900
     state: stopped\n  datacenter: dc1
     external_ip: 127.0.0.2
     internal_ip: 10.0.0.2
     platform: 
     provider:
```

```
```
